### PR TITLE
fix unmapped read reporting

### DIFF
--- a/bwameth.py
+++ b/bwameth.py
@@ -343,9 +343,7 @@ def handle_reads(alns, set_as_failed):
         assert len(aln.seq) == len(aln.qual), aln.read
         # don't need this any more.
         aln.other = [x for x in aln.other if not x.startswith('YS:Z')]
-        if aln.chrom == "*":  # chrom
-            continue
-
+        
         # first letter of chrom is 'f' or 'r'
         direction = aln.chrom[0]
         aln.chrom = aln.chrom.lstrip('fr')


### PR DESCRIPTION
now also unmapped reads are reported in their original (not converted) form.
